### PR TITLE
Fixed exception on first update after destroy

### DIFF
--- a/source/plugins/phasereditor2d.ninepatch/code-resources/js-module/NinePatch.js
+++ b/source/plugins/phasereditor2d.ninepatch/code-resources/js-module/NinePatch.js
@@ -15,7 +15,7 @@ export default class NinePatch extends Phaser.GameObjects.RenderTexture {
         this.textureFrame = frame;
         this._brush = new Phaser.GameObjects.TileSprite(scene, 0, 0, 1, 1, key, frame);
         this._brush.setOrigin(0, 0);
-        this.scene.events.once("update", () => this.redraw());
+        this.scene.events.once("update", this.redraw, this);
     }
     redraw() {
         this.clear();
@@ -96,5 +96,10 @@ export default class NinePatch extends Phaser.GameObjects.RenderTexture {
         this.textureFrame = frame;
         this.redraw();
         return this;
+    }
+    destroy() {
+        this.scene.events.off("update", this.redraw, this);
+
+        super.destroy()
     }
 }

--- a/source/plugins/phasereditor2d.ninepatch/code-resources/js-module/NinePatchContainer.js
+++ b/source/plugins/phasereditor2d.ninepatch/code-resources/js-module/NinePatchContainer.js
@@ -25,7 +25,7 @@ export default class NinePatchContainer extends Phaser.GameObjects.Container {
         this.height = height;
         this.textureKey = key;
         this.textureFrame = frame;
-        this.scene.events.once("update", () => this.redraw());
+        this.scene.events.once("update", this.redraw, this);
     }
     redraw() {
         this._originTexture = this.scene.textures.get(this.textureKey);
@@ -101,5 +101,10 @@ export default class NinePatchContainer extends Phaser.GameObjects.Container {
     }
     updateDisplayOrigin() {
         // nothing, a dummy method
+    }
+    destroy() {
+        this.scene.events.off("update", this.redraw, this);
+
+        super.destroy()
     }
 }

--- a/source/plugins/phasereditor2d.ninepatch/code-resources/js-module/NinePatchImage.js
+++ b/source/plugins/phasereditor2d.ninepatch/code-resources/js-module/NinePatchImage.js
@@ -15,7 +15,7 @@ export default class NinePatchImage extends Phaser.GameObjects.Image {
         this.height = height;
         this.textureKey = key;
         this.textureFrame = frame;
-        this.scene.events.once("update", () => this.redraw());
+        this.scene.events.once("update", this.redraw, this);
     }
     redraw() {
         const hashKey = [
@@ -126,5 +126,10 @@ export default class NinePatchImage extends Phaser.GameObjects.Image {
         rt.destroy();
         brush.destroy();
         textureImage.destroy();
+    }
+    destroy() {
+        this.scene.events.off("update", this.redraw, this);
+
+        super.destroy()
     }
 }

--- a/source/plugins/phasereditor2d.ninepatch/code-resources/js/NinePatch.js
+++ b/source/plugins/phasereditor2d.ninepatch/code-resources/js/NinePatch.js
@@ -14,7 +14,7 @@ class NinePatch extends Phaser.GameObjects.RenderTexture {
         this.textureFrame = frame;
         this._brush = new Phaser.GameObjects.TileSprite(scene, 0, 0, 1, 1, key, frame);
         this._brush.setOrigin(0, 0);
-        this.scene.events.once("update", () => this.redraw());
+        this.scene.events.once("update", this.redraw, this);
     }
     redraw() {
         this.clear();
@@ -95,5 +95,10 @@ class NinePatch extends Phaser.GameObjects.RenderTexture {
         this.textureFrame = frame;
         this.redraw();
         return this;
+    }
+    destroy() {
+        this.scene.events.off("update", this.redraw, this);
+
+        super.destroy()
     }
 }

--- a/source/plugins/phasereditor2d.ninepatch/code-resources/js/NinePatchContainer.js
+++ b/source/plugins/phasereditor2d.ninepatch/code-resources/js/NinePatchContainer.js
@@ -24,7 +24,7 @@ class NinePatchContainer extends Phaser.GameObjects.Container {
         this.height = height;
         this.textureKey = key;
         this.textureFrame = frame;
-        this.scene.events.once("update", () => this.redraw());
+        this.scene.events.once("update", this.redraw, this);
     }
     redraw() {
         this._originTexture = this.scene.textures.get(this.textureKey);
@@ -100,5 +100,10 @@ class NinePatchContainer extends Phaser.GameObjects.Container {
     }
     updateDisplayOrigin() {
         // nothing, a dummy method
+    }
+    destroy() {
+        this.scene.events.off("update", this.redraw, this);
+
+        super.destroy()
     }
 }

--- a/source/plugins/phasereditor2d.ninepatch/code-resources/js/NinePatchImage.js
+++ b/source/plugins/phasereditor2d.ninepatch/code-resources/js/NinePatchImage.js
@@ -14,7 +14,7 @@ class NinePatchImage extends Phaser.GameObjects.Image {
         this.height = height;
         this.textureKey = key;
         this.textureFrame = frame;
-        this.scene.events.once("update", () => this.redraw());
+        this.scene.events.once("update", this.redraw, this);
     }
     redraw() {
         const hashKey = [
@@ -125,5 +125,10 @@ class NinePatchImage extends Phaser.GameObjects.Image {
         rt.destroy();
         brush.destroy();
         textureImage.destroy();
+    }
+    destroy() {
+        this.scene.events.off("update", this.redraw, this);
+
+        super.destroy()
     }
 }

--- a/source/plugins/phasereditor2d.ninepatch/code-resources/ts-module/NinePatch.ts
+++ b/source/plugins/phasereditor2d.ninepatch/code-resources/ts-module/NinePatch.ts
@@ -20,7 +20,7 @@ export default class NinePatch extends Phaser.GameObjects.RenderTexture {
         this._brush = new Phaser.GameObjects.TileSprite(scene, 0, 0, 1, 1, key, frame);
         this._brush.setOrigin(0, 0);
 
-        this.scene.events.once("update", () => this.redraw());
+        this.scene.events.once("update", this.redraw, this);
     }
 
     redraw(): void {
@@ -131,5 +131,10 @@ export default class NinePatch extends Phaser.GameObjects.RenderTexture {
         this.redraw();
 
         return this;
+    }
+    destroy() {
+        this.scene.events.off("update", this.redraw, this);
+
+        super.destroy()
     }
 }

--- a/source/plugins/phasereditor2d.ninepatch/code-resources/ts-module/NinePatchContainer.ts
+++ b/source/plugins/phasereditor2d.ninepatch/code-resources/ts-module/NinePatchContainer.ts
@@ -31,7 +31,7 @@ export default class NinePatchContainer extends Phaser.GameObjects.Container {
         this.textureKey = key;
         this.textureFrame = frame;
 
-        this.scene.events.once("update", () => this.redraw());
+        this.scene.events.once("update", this.redraw, this);
     }
 
     redraw() {
@@ -155,5 +155,10 @@ export default class NinePatchContainer extends Phaser.GameObjects.Container {
 
     updateDisplayOrigin() {
         // nothing, a dummy method
+    }
+    destroy() {
+        this.scene.events.off("update", this.redraw, this);
+
+        super.destroy()
     }
 }

--- a/source/plugins/phasereditor2d.ninepatch/code-resources/ts-module/NinePatchImage.ts
+++ b/source/plugins/phasereditor2d.ninepatch/code-resources/ts-module/NinePatchImage.ts
@@ -20,7 +20,7 @@ export default class NinePatchImage extends Phaser.GameObjects.Image {
         this.textureKey = key;
         this.textureFrame = frame;
 
-        this.scene.events.once("update", () => this.redraw());
+        this.scene.events.once("update", this.redraw, this);
     }
 
     redraw(): void {
@@ -174,5 +174,10 @@ export default class NinePatchImage extends Phaser.GameObjects.Image {
         rt.destroy();
         brush.destroy();
         textureImage.destroy();
+    }
+    destroy() {
+        this.scene.events.off("update", this.redraw, this);
+
+        super.destroy()
     }
 }

--- a/source/plugins/phasereditor2d.ninepatch/code-resources/ts/NinePatch.ts
+++ b/source/plugins/phasereditor2d.ninepatch/code-resources/ts/NinePatch.ts
@@ -20,7 +20,7 @@ class NinePatch extends Phaser.GameObjects.RenderTexture {
         this._brush = new Phaser.GameObjects.TileSprite(scene, 0, 0, 1, 1, key, frame);
         this._brush.setOrigin(0, 0);
 
-        this.scene.events.once("update", () => this.redraw());
+        this.scene.events.once("update", this.redraw, this);
     }
 
     redraw(): void {
@@ -131,5 +131,10 @@ class NinePatch extends Phaser.GameObjects.RenderTexture {
         this.redraw();
 
         return this;
+    }
+    destroy() {
+        this.scene.events.off("update", this.redraw, this);
+
+        super.destroy()
     }
 }

--- a/source/plugins/phasereditor2d.ninepatch/code-resources/ts/NinePatchContainer.ts
+++ b/source/plugins/phasereditor2d.ninepatch/code-resources/ts/NinePatchContainer.ts
@@ -31,7 +31,7 @@ class NinePatchContainer extends Phaser.GameObjects.Container {
         this.textureKey = key;
         this.textureFrame = frame;
 
-        this.scene.events.once("update", () => this.redraw());
+        this.scene.events.once("update", this.redraw, this);
     }
 
     redraw() {
@@ -155,5 +155,10 @@ class NinePatchContainer extends Phaser.GameObjects.Container {
 
     updateDisplayOrigin() {
         // nothing, a dummy method
+    }
+    destroy() {
+        this.scene.events.off("update", this.redraw, this);
+
+        super.destroy()
     }
 }

--- a/source/plugins/phasereditor2d.ninepatch/code-resources/ts/NinePatchImage.ts
+++ b/source/plugins/phasereditor2d.ninepatch/code-resources/ts/NinePatchImage.ts
@@ -20,7 +20,7 @@ class NinePatchImage extends Phaser.GameObjects.Image {
         this.textureKey = key;
         this.textureFrame = frame;
 
-        this.scene.events.once("update", () => this.redraw());
+        this.scene.events.once("update", this.redraw, this);
     }
 
     redraw(): void {
@@ -174,5 +174,10 @@ class NinePatchImage extends Phaser.GameObjects.Image {
         rt.destroy();
         brush.destroy();
         textureImage.destroy();
+    }
+    destroy() {
+        this.scene.events.off("update", this.redraw, this);
+
+        super.destroy()
     }
 }


### PR DESCRIPTION
If you call destroy before the first update, then when you call draw, this.scene == null and an exception is thrown

```
NinePatchImage.js:33 Uncaught TypeError: Cannot read properties of undefined (reading 'textures')
    at NinePatchImage.redraw (NinePatchImage.js:33:24)
    at EventEmitter.<anonymous> (NinePatchImage.js:18:53)
    at EventEmitter.emit (phaser.js:1928:1)
    at Systems.step (phaser.js:49066:1)
    at SceneManager.update (phaser.js:100289:1)
    at Game.step (phaser.js:162805:1)
    at TimeStep.step (phaser.js:89366:1)
    at step (phaser.js:89613:1)
```